### PR TITLE
Configure ignore paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ UPTEST_VERSION = v0.2.1
 # certain conventions such as the default examples root or package directory.
 XPKG_DIR = $(shell pwd)
 XPKG_EXAMPLES_DIR = .up/examples
+XPKG_IGNORE = .github/workflows/ci.yaml,.github/workflows/tag.yml
 
 XPKG_REG_ORGS ?= xpkg.upbound.io/upbound
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Since the top-level directory is the package root, we need to pass explicit paths to ignore.

We can't use wildcards AFAICT, and the flag splits on commas.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`make build`
