### PR TITLE
feat(): refactor, add XIRSA composition, optional path for xservice gitops locations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,4 +73,5 @@ jobs:
           password: ${{ secrets.XPKG_TOKEN }}
 
       - name: Publish Artifacts
+        if: env.XPKG_ACCESS_ID != ''
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,21 +4,26 @@ on:
   issue_comment:
     types: [created]
 
+env:
+  trigger-keyword: '/test-examples'
+  go-version: '1.19'
+  package-type: configuration
+
 jobs:
   debug:
     runs-on: [e2-standard-8, linux]
     steps:
       - name: Debug
         run: |
-          echo "Trigger keyword: ${{ inputs.trigger-keyword }}"
-          echo "Go version: ${{ inputs.go-version }}"
+          echo "Trigger keyword: ${{ env.trigger-keyword }}"
+          echo "Go version: ${{ env.go-version }}"
           echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
           echo "github.event.comment.body: ${{ github.event.comment.body }}"
 
   get-example-list:
     if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
             github.event.issue.pull_request &&
-            contains(github.event.comment.body, inputs.trigger-keyword ) }}
+            contains(github.event.comment.body, env.trigger-keyword ) }}
     runs-on: [e2-standard-8, linux]
     outputs:
       example_list: ${{ steps.get-example-list-name.outputs.example-list }}
@@ -45,7 +50,7 @@ jobs:
           COMMENT: ${{ github.event.comment.body }}
         id: get-example-list-name
         run: |
-          PATHS=$(echo $COMMENT | sed 's/^.*\${{ inputs.trigger-keyword }}="//g' | cut -d '"' -f 1 | sed 's/,/ /g')
+          PATHS=$(echo $COMMENT | sed 's/^.*\${{ env.trigger-keyword }}="//g' | cut -d '"' -f 1 | sed 's/,/ /g')
           EXAMPLE_LIST=""
           for P in $PATHS; do EXAMPLE_LIST="${EXAMPLE_LIST},$(find $P -name '*.yaml' | tr '\n' ',')"; done
 
@@ -75,7 +80,7 @@ jobs:
   uptest:
     if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' ) &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, inputs.trigger-keyword ) }}
+      contains(github.event.comment.body, env.trigger-keyword ) }}
     runs-on: [e2-standard-8, linux]
     needs: get-example-list
 
@@ -93,7 +98,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ${{ env.go-version }}
 
       - name: Checkout PR
         id: checkout-pr
@@ -106,12 +111,12 @@ jobs:
           echo "commit-sha=$OUTPUT" >> $GITHUB_OUTPUT
 
       - name: Find the Go Build Cache
-        if: ${{ inputs.package-type  == 'provider' }}
+        if: ${{ env.package-type  == 'provider' }}
         id: go
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        if: ${{ inputs.package-type  == 'provider' }}
+        if: ${{ env.package-type  == 'provider' }}
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ${{ steps.go.outputs.cache }}
@@ -119,7 +124,7 @@ jobs:
           restore-keys: ${{ runner.os }}-build-uptest-
 
       - name: Cache Go Dependencies
-        if: ${{ inputs.package-type  == 'provider' }}
+        if: ${{ env.package-type  == 'provider' }}
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: .work/pkg
@@ -127,7 +132,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
-        if: ${{ inputs.package-type  == 'provider' }}
+        if: ${{ env.package-type  == 'provider' }}
         run: make vendor vendor.check
 
       - name: Run Uptest

--- a/.up/examples/aws/gitops-master-cluster.yaml
+++ b/.up/examples/aws/gitops-master-cluster.yaml
@@ -11,7 +11,7 @@ spec:
     version: "1.27"
     nodes:
       count: 3
-      size: small
+      instanceType: t3.small
     serviceSelector: gitops-master
     gitops:
       url: https://github.com/upbound/caas-cluster-configuration

--- a/.up/examples/aws/irsa.yaml
+++ b/.up/examples/aws/irsa.yaml
@@ -1,0 +1,26 @@
+apiVersion: aws.caas.upbound.io/v1alpha1
+kind: XIRSA
+metadata:
+  name: aws-spoke-01-kustomize-controller
+spec:
+  parameters:
+    deletionPolicy: Delete
+    id: aws-spoke-01
+    condition: StringEquals
+    policyDocument: |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Action": [
+                      "kms:Decrypt",
+                      "kms:DescribeKey"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+              }
+          ]
+      }
+    serviceAccount:
+      name: kustomize-controller
+      namespace: flux-system

--- a/.up/examples/aws/spoke-cluster.yaml
+++ b/.up/examples/aws/spoke-cluster.yaml
@@ -10,8 +10,12 @@ spec:
     id: aws-spoke-01
     region: eu-central-1
     version: "1.27"
+    iam:
+      roleArn: arn:aws:iam::609897127049:role/AWSReservedSSO_AdministratorAccess_d703c73ed340fde7
     nodes:
       count: 3
-      size: small
+      instanceType: t3.small
+    gitops:
+      url: https://github.com/upbound/caas-cluster-configuration
   writeConnectionSecretToRef:
     name: aws-spoke-01-kubeconfig

--- a/.up/examples/azure/gitops-master-cluster.yaml
+++ b/.up/examples/azure/gitops-master-cluster.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   parameters:
     id: gitops-master
-    region: West Europe
+    region: West US
     version: "1.27.3"
     nodes:
       count: 3
-      size: small
+      instanceType: Standard_B2s
     serviceSelector: gitops-master
     gitops:
       url: https://github.com/upbound/caas-cluster-configuration

--- a/.up/examples/azure/spoke-cluster.yaml
+++ b/.up/examples/azure/spoke-cluster.yaml
@@ -8,10 +8,12 @@ metadata:
 spec:
   parameters:
     id: azure-spoke-02
-    region: West Europe
+    region: West US
     version: "1.27.3"
     nodes:
       count: 3
-      size: small
+      instanceType: Standard_B2s
+    gitops:
+      url: https://github.com/upbound/caas-cluster-configuration
   writeConnectionSecretToRef:
     name: azure-spoke-02-kubeconfig

--- a/.up/examples/gcp/gitops-master-cluster.yaml
+++ b/.up/examples/gcp/gitops-master-cluster.yaml
@@ -11,7 +11,7 @@ spec:
     version: "latest"
     nodes:
       count: 3
-      size: small
+      instanceType: n1-standard-4
     serviceSelector: gitops-master
     gitops:
       url: https://github.com/upbound/caas-cluster-configuration

--- a/.up/examples/gcp/spoke-cluster.yaml
+++ b/.up/examples/gcp/spoke-cluster.yaml
@@ -12,6 +12,8 @@ spec:
     version: "latest"
     nodes:
       count: 3
-      size: small
+      instanceType: n1-standard-4
+    gitops:
+      url: https://github.com/upbound/caas-cluster-configuration
   writeConnectionSecretToRef:
     name: gcp-spoke-02-kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,9 @@ PLATFORMS ?= linux_amd64
 # ====================================================================================
 # Setup Kubernetes tools
 
-UP_VERSION = v0.18.0
+UP_VERSION = v0.19.1
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.5.0
-UPTEST_CLAIMS = .up/examples/aws/spoke-cluster.yaml,.up/examples/azure/spoke-cluster.yaml,.up/examples/gcp/spoke-cluster.yaml
 -include build/makelib/k8s_tools.mk
 # ====================================================================================
 # Setup XPKG
@@ -23,7 +22,7 @@ UPTEST_CLAIMS = .up/examples/aws/spoke-cluster.yaml,.up/examples/azure/spoke-clu
 # certain conventions such as the default examples root or package directory.
 XPKG_DIR = $(shell pwd)
 XPKG_EXAMPLES_DIR = .up/examples
-XPKG_IGNORE = .github/workflows/ci.yaml,.github/workflows/tag.yml,.github/workflows/e2e.yaml,test/setup.sh
+XPKG_IGNORE = .github/workflows/ci.yaml,.github/workflows/tag.yml,.github/workflows/e2e.yaml,init/*.yaml,.up/examples/aws/*.yaml,.up/examples/azure/*.yaml,.up/examples/gcp/*.yaml,.up/examples/upbound/*.yaml,.work/uptest-datasource.yaml
 
 XPKG_REG_ORGS ?= xpkg.upbound.io/upbound
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
@@ -68,7 +67,7 @@ build.init: $(UP)
 #   You can check the basic implementation here: https://github.com/upbound/uptest/blob/main/internal/templates/01-delete.yaml.tmpl.
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e $(UPTEST_CLAIMS) --setup-script=test/setup.sh --default-timeout=4800 || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e "${UPTEST_EXAMPLE_LIST}" --setup-script=test/setup.sh --default-timeout=3200 || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:

--- a/apis/aws/composition.yaml
+++ b/apis/aws/composition.yaml
@@ -73,7 +73,7 @@ spec:
       name: compositeClusterServices
       patches:
         - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
         - fromFieldPath: spec.parameters.id
           toFieldPath: spec.providerConfigRef.name
         - fromFieldPath: spec.parameters.services.operators.flux.version

--- a/apis/aws/composition.yaml
+++ b/apis/aws/composition.yaml
@@ -57,8 +57,12 @@ spec:
           toFieldPath: spec.parameters.version
         - fromFieldPath: spec.parameters.nodes.count
           toFieldPath: spec.parameters.nodes.count
-        - fromFieldPath: spec.parameters.nodes.size
-          toFieldPath: spec.parameters.nodes.size
+        - fromFieldPath: spec.parameters.nodes.instanceType
+          toFieldPath: spec.parameters.nodes.instanceType
+        - fromFieldPath: spec.parameters.iam.roleArn
+          toFieldPath: spec.parameters.iam.roleArn
+        - fromFieldPath: spec.parameters.iam.userArn
+          toFieldPath: spec.parameters.iam.userArn
         - fromFieldPath: status.subnetIds
           toFieldPath: spec.parameters.subnetIds
           policy:
@@ -76,6 +80,8 @@ spec:
           toFieldPath: spec.operators.flux.version
         - fromFieldPath: spec.parameters.gitops.url
           toFieldPath: spec.gitops.url
+        - fromFieldPath: spec.parameters.gitops.path
+          toFieldPath: spec.gitops.path
         - fromFieldPath: spec.parameters.gitops.kubeConfigSecretRef.name
           toFieldPath: spec.gitops.kubeConfigSecretRef.name
         - fromFieldPath: spec.parameters.gitops.kubeConfigSecretRef.namespace

--- a/apis/aws/definition.yaml
+++ b/apis/aws/definition.yaml
@@ -33,6 +33,16 @@ spec:
                   region:
                     type: string
                     description: Region is the region you'd like your resource to be created in.
+                  iam:
+                    type: object
+                    description: IAM configuration to connect as ClusterAdmin.
+                    properties:
+                      roleArn:
+                        description: The IAM Role ARN to connect as ClusterAdmin.
+                        type: string
+                      userArn:
+                        description: The IAM User ARN to connect as ClusterAdmin.
+                        type: string
                   networkSelector:
                     type: string
                     description: NetworkSelector employs a specific type of network architecture.
@@ -73,16 +83,13 @@ spec:
                       count:
                         type: integer
                         description: Desired node count, from 1 to 100.
-                      size:
+                      instanceType:
                         type: string
-                        description: Size of node.
-                        enum:
-                        - small
-                        - medium
-                        - large
+                        description: instance types associated with the Node Group.
+                        default: t3.small
                     required:
                     - count
-                    - size
+                    - instanceType
                   gitops:
                     type: object
                     description: GitOps configure external gitops system for mcp controlplane
@@ -90,6 +97,9 @@ spec:
                       url:
                         type: string
                         description: Url for GitOps Sync.
+                      path:
+                        type: string
+                        description: path in Repo for GitOps Sync.
                       kubeConfigSecretRef:
                         type: object
                         description: location for kubeconfig mcp controlplane
@@ -104,7 +114,6 @@ spec:
                         - name
                         - namespace
                     required:
-                    - kubeConfigSecretRef
                     - url
                   services:
                     type: object

--- a/apis/aws/eks/composition.yaml
+++ b/apis/aws/eks/composition.yaml
@@ -338,8 +338,6 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.id
           toFieldPath: metadata.name
-        - type: PatchSet
-          patchSetName: deletionPolicy
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.credentials.secretRef.namespace
         - fromFieldPath: metadata.uid
@@ -362,8 +360,6 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.id
           toFieldPath: metadata.name
-        - type: PatchSet
-          patchSetName: deletionPolicy
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.credentials.secretRef.namespace
         - fromFieldPath: metadata.uid

--- a/apis/aws/eks/composition.yaml
+++ b/apis/aws/eks/composition.yaml
@@ -180,6 +180,11 @@ spec:
           patchSetName: providerConfigRef
         - type: PatchSet
           patchSetName: deletionPolicy
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.eks.nodeGroupRoleArn
+          policy:
+            fromFieldPath: Optional
     - base:
         apiVersion: iam.aws.upbound.io/v1beta1
         kind: RolePolicyAttachment
@@ -274,14 +279,8 @@ spec:
           patchSetName: region
         - fromFieldPath: spec.parameters.nodes.count
           toFieldPath: spec.forProvider.scalingConfig[0].desiredSize
-        - fromFieldPath: spec.parameters.nodes.size
+        - fromFieldPath: spec.parameters.nodes.instanceType
           toFieldPath: spec.forProvider.instanceTypes[0]
-          transforms:
-            - type: map
-              map:
-                small: t3.small
-                medium: t3.medium
-                large: t3.large
         - fromFieldPath: spec.parameters.id
           toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.caas.upbound.io/network-id]
     - base:
@@ -322,6 +321,11 @@ spec:
           toFieldPath: spec.forProvider.url
           policy:
             fromFieldPath: Required
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.eks.oidcArn
+          policy:
+            fromFieldPath: Optional
     - base:
         apiVersion: helm.crossplane.io/v1beta1
         kind: ProviderConfig
@@ -370,3 +374,82 @@ spec:
                 fmt: "%s-ekscluster"
       readinessChecks:
         - type: None
+    - name: irsa-settings
+      base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        spec:
+          deletionPolicy: Orphan
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                namespace: default
+      patches:
+        - fromFieldPath: spec.parameters.id
+          toFieldPath: spec.providerConfigRef.name
+        - fromFieldPath: spec.parameters.id
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-irsa-settings"
+        - fromFieldPath: spec.parameters.id
+          toFieldPath: spec.forProvider.manifest.metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-irsa-settings"
+        - fromFieldPath: status.eks.oidcArn
+          toFieldPath: spec.forProvider.manifest.data.oidc_arn
+        - fromFieldPath: status.eks.oidcUri
+          toFieldPath: spec.forProvider.manifest.data.oidc_host
+
+    - name: aws-auth
+      base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        spec:
+          deletionPolicy: Orphan
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                namespace: kube-system
+                name: aws-auth
+      patches:
+        - fromFieldPath: spec.parameters.id
+          toFieldPath: spec.providerConfigRef.name
+        - fromFieldPath: spec.parameters.id
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-aws-auth"
+        - type: CombineFromComposite
+          combine:
+            variables:
+            - fromFieldPath: status.eks.nodeGroupRoleArn
+            - fromFieldPath: spec.parameters.iam.userArn
+            - fromFieldPath: spec.parameters.iam.roleArn
+            strategy: string
+            string:
+              fmt: |
+                - groups:
+                  - system:bootstrappers
+                  - system:nodes
+                  rolearn: %s
+                  username: system:node:{{EC2PrivateDNSName}}
+                - groups:
+                  - system:masters
+                  userarn: %s
+                  username: adminuser
+                - groups:
+                  - system:masters
+                  rolearn: %s
+                  username: adminrole
+          toFieldPath: spec.forProvider.manifest.data.mapRoles
+          policy:
+            fromFieldPath: Optional

--- a/apis/aws/eks/definition.yaml
+++ b/apis/aws/eks/definition.yaml
@@ -30,6 +30,18 @@ spec:
                   region:
                     type: string
                     description: Region is the region you'd like your resource to be created in.
+                  iam:
+                    type: object
+                    description: IAM configuration to connect as ClusterAdmin.
+                    properties:
+                      roleArn:
+                        description: The IAM Role ARN to connect as ClusterAdmin.
+                        type: string
+                        default: roleArn
+                      userArn:
+                        description: The IAM User ARN to connect as ClusterAdmin.
+                        type: string
+                        default: userArn
                   deletionPolicy:
                     description: When the Composition is deleted, delete the AWS resources. Defaults to Delete
                     enum:
@@ -61,16 +73,13 @@ spec:
                       count:
                         type: integer
                         description: Desired node count, from 1 to 100.
-                      size:
+                      instanceType:
                         type: string
-                        description: Size of node.
-                        enum:
-                        - small
-                        - medium
-                        - large
+                        description: instance types associated with the Node Group.
+                        default: t3.small
                     required:
                     - count
-                    - size
+                    - instanceType
                 required:
                 - id
                 - region

--- a/apis/aws/irsa/composition.yaml
+++ b/apis/aws/irsa/composition.yaml
@@ -1,0 +1,170 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xirsas.aws.caas.upbound.io
+spec:
+  compositeTypeRef:
+    apiVersion: aws.caas.upbound.io/v1alpha1
+    kind: XIRSA
+  patchSets:
+    - name: Name
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+    - name: providerConfigRef
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+    - name: deletionPolicy
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+
+  resources:
+    - name: irsa-role
+      base:
+        apiVersion: iam.aws.upbound.io/v1beta1
+        kind: Role
+        metadata:
+          labels:
+            resource: "Role"
+      patches:
+        - type: PatchSet
+          patchSetName: Name
+        - type: PatchSet
+          patchSetName: providerConfigRef
+        - type: PatchSet
+          patchSetName: deletionPolicy
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.roleArn
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.conditions
+          toFieldPath: status.observed.role.conditions
+          policy:
+            fromFieldPath: Optional
+        - type: CombineFromComposite
+          toFieldPath: spec.forProvider.assumeRolePolicy
+          combine:
+            strategy: string
+            variables:
+            - fromFieldPath: status.irsa.oidc_arn
+            - fromFieldPath: spec.parameters.condition
+            - fromFieldPath: status.irsa.oidc_host
+            - fromFieldPath: spec.parameters.serviceAccount.namespace
+            - fromFieldPath: spec.parameters.serviceAccount.name
+            string:
+              fmt: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Principal": {
+                        "Federated": "%s"
+                      },
+                      "Action": "sts:AssumeRoleWithWebIdentity",
+                      "Condition": {
+                        "%s": {
+                          "%s:sub": "system:serviceaccount:%s:%s"
+                        }
+                      }
+                    }
+                  ]
+                }
+
+    - name: irsa-policy
+      base:
+        apiVersion: iam.aws.upbound.io/v1beta1
+        kind: Policy
+        metadata:
+          labels:
+            resource: "Policy"
+      patches:
+        - type: PatchSet
+          patchSetName: providerConfigRef
+        - type: PatchSet
+          patchSetName: deletionPolicy
+        - fromFieldPath: spec.parameters.policyDocument
+          toFieldPath: spec.forProvider.policy
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          toFieldPath: status.policyArn
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.conditions
+          toFieldPath: status.observed.policy.conditions
+          policy:
+            fromFieldPath: Optional
+
+    - name: irsa-attachment
+      base:
+        apiVersion: iam.aws.upbound.io/v1beta1
+        kind: RolePolicyAttachment
+        metadata:
+          labels:
+            resource: "RolePolicyAttachment"
+        spec:
+          forProvider:
+            policyArnSelector:
+              matchControllerRef: true
+              matchLabels:
+                resource: "Policy"
+            roleSelector:
+              matchControllerRef: true
+              matchLabels:
+                resource: "Role"
+      patches:
+        - type: PatchSet
+          patchSetName: providerConfigRef
+        - type: PatchSet
+          patchSetName: deletionPolicy
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.conditions
+          toFieldPath: status.observed.rpa.conditions
+          policy:
+            fromFieldPath: Optional
+
+    - name: irsa-settings
+      base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        spec:
+          managementPolicy: Observe
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                namespace: default
+      patches:
+        - fromFieldPath: spec.parameters.id
+          toFieldPath: spec.providerConfigRef.name
+        - type: PatchSet
+          patchSetName: deletionPolicy
+        - fromFieldPath: spec.parameters.id
+          toFieldPath: "metadata.annotations[crossplane.io/external-name]"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-irsa-settings"
+        - fromFieldPath: spec.parameters.id
+          toFieldPath:  "spec.forProvider.manifest.metadata.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-irsa-settings"
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.manifest.data.oidc_arn
+          toFieldPath: status.irsa.oidc_arn
+          policy:
+            fromFieldPath: Optional
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.manifest.data.oidc_host
+          toFieldPath: status.irsa.oidc_host
+          policy:
+            fromFieldPath: Optional

--- a/apis/aws/irsa/definition.yaml
+++ b/apis/aws/irsa/definition.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xirsas.aws.caas.upbound.io
+  labels:
+    provider: aws
+spec:
+  group: aws.caas.upbound.io
+  names:
+    kind: XIRSA
+    plural: xirsas
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              parameters:
+                type: object
+                description: IRSA configuration parameters.
+                properties:
+                  id:
+                    type: string
+                    description: ID of this Cluster that other objects will use to refer to it.
+                  deletionPolicy:
+                    description: When the Composition is deleleted, delelete the AWS resources. Defaults to Delete
+                    enum:
+                    - Delete
+                    - Orphan
+                    type: string
+                    default: Delete
+                  providerConfigName:
+                    description: Crossplane ProviderConfig to use for provisioning this resources
+                    type: string
+                    default: default
+                  serviceAccount:
+                    type: object
+                    description: Configuration for SA
+                    properties:
+                      name:
+                        type: string
+                        description: name kubernetes SA
+                      namespace:
+                        type: string
+                        description: namespace kubernetes SA
+                    required:
+                    - name
+                    - namespace
+                  condition:
+                    type: string
+                    description: This is the whether or not the equals is a hard match or like query
+                    default: StringEquals
+                    enum:
+                    - StringEquals
+                    - StringLike
+                  policyDocument:
+                    type: string
+                    description: The JSON policy document that is the content for the policy.
+                required:
+                - id
+                - condition
+                - policyDocument
+                - serviceAccount
+            required:
+            - parameters
+          status:
+            type: object
+            properties:
+              irsa:
+                description: Freeform field containing status information for irsa
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              roleArn:
+                description: The arn of the role
+                type: string
+              policyArn:
+                description: The arn of the policy
+                type: string
+              observed:
+                description: Freeform field containing information about the observed status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true

--- a/apis/aws/network/basic/composition.yaml
+++ b/apis/aws/network/basic/composition.yaml
@@ -41,8 +41,7 @@ spec:
             enableDnsSupport: true
             enableDnsHostnames: true
             tags:
-              Owner: Platform Team
-              Name: caas-vpc
+              Name: ""
       name: caas-vcp
       patches:
         - type: PatchSet
@@ -53,6 +52,8 @@ spec:
           patchSetName: network-id
         - type: PatchSet
           patchSetName: region
+        - fromFieldPath: metadata.name
+          toFieldPath: spec.forProvider.tags["Name"]
     - base:
         apiVersion: ec2.aws.upbound.io/v1beta1
         kind: InternetGateway

--- a/apis/aws/services/default/composition.yaml
+++ b/apis/aws/services/default/composition.yaml
@@ -9,6 +9,21 @@ spec:
   compositeTypeRef:
     apiVersion: aws.caas.upbound.io/v1alpha1
     kind: XServices
+  patchSets:
+  - name: Common
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.labels
+      toFieldPath: metadata.labels
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.annotations
+      toFieldPath: metadata.annotations
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.providerConfigRef.name
+      toFieldPath: spec.providerConfigRef.name
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux
       base:
@@ -28,14 +43,8 @@ spec:
               imageReflectionController:
                 create: false
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.operators.flux.version
           toFieldPath: spec.forProvider.chart.version
         - type: CombineFromComposite
@@ -47,3 +56,44 @@ spec:
             string:
               fmt: https://github.com/fluxcd-community/helm-charts/releases/download/flux2-%s/flux2-%s.tgz
           toFieldPath: spec.forProvider.chart.url
+    - name: syncFlux
+      base:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        spec:
+          rollbackLimit: 3
+          forProvider:
+            namespace: flux-system
+            chart:
+              name: flux2-sync
+              repository: https://fluxcd-community.github.io/helm-charts
+              # ToDo(haarchri): patch from outside
+              version: "1.6.2"
+            values:
+              gitRepository:
+                spec:
+                  timeout: 20s
+                  interval: 10m0s
+                  gitImplementation: go-git
+                  ref:
+                    branch: main
+              kustomization:
+                spec:
+                  interval: 10m
+                  sourceRef:
+                    kind: GitRepository
+      patches:
+        - type: PatchSet
+          patchSetName: Common
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: spec.gitops.url
+          toFieldPath: spec.forProvider.values.gitRepository.spec.url
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: spec.forProvider.values.kustomization.spec.path
+          transforms:
+            - type: string
+              string:
+                fmt: "./infrastructure/%s"
+        - fromFieldPath: spec.gitops.path
+          toFieldPath: spec.forProvider.values.kustomization.spec.path

--- a/apis/aws/services/default/composition.yaml
+++ b/apis/aws/services/default/composition.yaml
@@ -22,7 +22,7 @@ spec:
       fromFieldPath: spec.providerConfigRef.name
       toFieldPath: spec.providerConfigRef.name
     - type: FromCompositeFieldPath
-      fromFieldPath: spec.parameters.deletionPolicy
+      fromFieldPath: spec.deletionPolicy
       toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux

--- a/apis/aws/services/definition.yaml
+++ b/apis/aws/services/definition.yaml
@@ -32,6 +32,9 @@ spec:
                   url:
                     type: string
                     description: Url for GitOps Sync.
+                  path:
+                    type: string
+                    description: path in Repo for GitOps Sync.
                   kubeConfigSecretRef:
                     type: object
                     description: location for kubeconfig mcp controlplane
@@ -46,7 +49,6 @@ spec:
                     - name
                     - namespace
                 required:
-                - kubeConfigSecretRef
                 - url
               operators:
                 type: object

--- a/apis/aws/services/gitops-master/composition.yaml
+++ b/apis/aws/services/gitops-master/composition.yaml
@@ -22,7 +22,7 @@ spec:
       fromFieldPath: spec.providerConfigRef.name
       toFieldPath: spec.providerConfigRef.name
     - type: FromCompositeFieldPath
-      fromFieldPath: spec.parameters.deletionPolicy
+      fromFieldPath: spec.deletionPolicy
       toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux

--- a/apis/aws/services/gitops-master/composition.yaml
+++ b/apis/aws/services/gitops-master/composition.yaml
@@ -9,6 +9,21 @@ spec:
   compositeTypeRef:
     apiVersion: aws.caas.upbound.io/v1alpha1
     kind: XServices
+  patchSets:
+  - name: Common
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.labels
+      toFieldPath: metadata.labels
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.annotations
+      toFieldPath: metadata.annotations
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.providerConfigRef.name
+      toFieldPath: spec.providerConfigRef.name
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux
       base:
@@ -28,14 +43,8 @@ spec:
               imageReflectionController:
                 create: false
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.operators.flux.version
           toFieldPath: spec.forProvider.chart.version
         - type: CombineFromComposite
@@ -65,14 +74,8 @@ spec:
               metadata:
                 namespace: flux-system
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.gitops.kubeConfigSecretRef.name
           toFieldPath: spec.references[0].patchesFrom.name
         - fromFieldPath: spec.gitops.kubeConfigSecretRef.namespace
@@ -110,14 +113,8 @@ spec:
                     secretRef:
                       key: kubeconfig
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.providerConfigRef.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
         - fromFieldPath: spec.gitops.url

--- a/apis/azure/aks/composition.yaml
+++ b/apis/azure/aks/composition.yaml
@@ -83,8 +83,6 @@ spec:
     patches:
     - fromFieldPath: spec.parameters.id
       toFieldPath: metadata.name
-    - type: PatchSet
-      patchSetName: deletionPolicy
     - fromFieldPath: spec.writeConnectionSecretToRef.namespace
       toFieldPath: spec.credentials.secretRef.namespace
     - fromFieldPath: metadata.uid
@@ -107,8 +105,6 @@ spec:
     patches:
     - fromFieldPath: spec.parameters.id
       toFieldPath: metadata.name
-    - type: PatchSet
-      patchSetName: deletionPolicy
     - fromFieldPath: spec.writeConnectionSecretToRef.namespace
       toFieldPath: spec.credentials.secretRef.namespace
     - fromFieldPath: metadata.uid

--- a/apis/azure/aks/composition.yaml
+++ b/apis/azure/aks/composition.yaml
@@ -10,118 +10,112 @@ spec:
     apiVersion: azure.caas.upbound.io/v1alpha1
     kind: XAKS
   patchSets:
-    - name: providerConfigRef
-      patches:
-      - type: FromCompositeFieldPath
-        fromFieldPath: spec.parameters.providerConfigName
-        toFieldPath: spec.providerConfigRef.name
-    - name: deletionPolicy
-      patches:
-      - type: FromCompositeFieldPath
-        fromFieldPath: spec.parameters.deletionPolicy
-        toFieldPath: spec.deletionPolicy
-    - name: region
-      patches:
-      - type: FromCompositeFieldPath
-        fromFieldPath: spec.parameters.region
-        toFieldPath: spec.forProvider.location
+  - name: providerConfigRef
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.providerConfigName
+      toFieldPath: spec.providerConfigRef.name
+  - name: deletionPolicy
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
+  - name: region
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.region
+      toFieldPath: spec.forProvider.location
   resources:
-    - name: kubernetes-cluster
-      base:
-        apiVersion: containerservice.azure.upbound.io/v1beta1
-        kind: KubernetesCluster
-        spec:
-          forProvider:
-            defaultNodePool:
-              - name: default
-            identity:
-              - type: "SystemAssigned"
-      patches:
-        - type: PatchSet
-          patchSetName: providerConfigRef
-        - type: PatchSet
-          patchSetName: deletionPolicy
-        - type: PatchSet
-          patchSetName: region
-        - fromFieldPath: spec.parameters.version
-          toFieldPath: spec.forProvider.kubernetesVersion
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: metadata.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-aks"
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: spec.forProvider.resourceGroupNameSelector.matchLabels[azure.caas.upbound.io/network-id]
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: spec.forProvider.defaultNodePool[0].vnetSubnetIdSelector.matchLabels[azure.caas.upbound.io/network-id]
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: spec.forProvider.dnsPrefix
-        - fromFieldPath: spec.parameters.nodes.size
-          toFieldPath: spec.forProvider.defaultNodePool[0].vmSize
-          transforms:
-            - type: map
-              map:
-                small: Standard_B2s
-                medium: Standard_B4ms
-                large: Standard_B8ms
-        - fromFieldPath: spec.parameters.nodes.count
-          toFieldPath: spec.forProvider.defaultNodePool[0].nodeCount
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-akscluster"
-      connectionDetails:
-        - fromConnectionSecretKey: kubeconfig
-    - name: providerConfig-helm
-      base:
-        apiVersion: helm.crossplane.io/v1beta1
-        kind: ProviderConfig
-        spec:
-          credentials:
-            source: Secret
-            secretRef:
-              key: kubeconfig
-      patches:
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: metadata.name
-        - type: PatchSet
-          patchSetName: deletionPolicy
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.credentials.secretRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.credentials.secretRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-akscluster"
-      readinessChecks:
-        - type: None
-    - name: providerConfig-kubernetes
-      base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        kind: ProviderConfig
-        spec:
-          credentials:
-            source: Secret
-            secretRef:
-              key: kubeconfig
-      patches:
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: metadata.name
-        - type: PatchSet
-          patchSetName: deletionPolicy
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.credentials.secretRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.credentials.secretRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-akscluster"
-      readinessChecks:
-        - type: None
+  - name: kubernetes-cluster
+    base:
+      apiVersion: containerservice.azure.upbound.io/v1beta1
+      kind: KubernetesCluster
+      spec:
+        forProvider:
+          defaultNodePool:
+          - name: default
+          identity:
+          - type: "SystemAssigned"
+    patches:
+    - type: PatchSet
+      patchSetName: providerConfigRef
+    - type: PatchSet
+      patchSetName: deletionPolicy
+    - type: PatchSet
+      patchSetName: region
+    - fromFieldPath: spec.parameters.version
+      toFieldPath: spec.forProvider.kubernetesVersion
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: metadata.name
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-aks"
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: spec.forProvider.resourceGroupNameSelector.matchLabels[azure.caas.upbound.io/network-id]
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: spec.forProvider.defaultNodePool[0].vnetSubnetIdSelector.matchLabels[azure.caas.upbound.io/network-id]
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: spec.forProvider.dnsPrefix
+    - fromFieldPath: spec.parameters.nodes.instanceType
+      toFieldPath: spec.forProvider.defaultNodePool[0].vmSize
+    - fromFieldPath: spec.parameters.nodes.count
+      toFieldPath: spec.forProvider.defaultNodePool[0].nodeCount
+    - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+      toFieldPath: spec.writeConnectionSecretToRef.namespace
+    - fromFieldPath: metadata.uid
+      toFieldPath: spec.writeConnectionSecretToRef.name
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-akscluster"
+    connectionDetails:
+    - fromConnectionSecretKey: kubeconfig
+  - name: providerConfig-helm
+    base:
+      apiVersion: helm.crossplane.io/v1beta1
+      kind: ProviderConfig
+      spec:
+        credentials:
+          source: Secret
+          secretRef:
+            key: kubeconfig
+    patches:
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: metadata.name
+    - type: PatchSet
+      patchSetName: deletionPolicy
+    - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+      toFieldPath: spec.credentials.secretRef.namespace
+    - fromFieldPath: metadata.uid
+      toFieldPath: spec.credentials.secretRef.name
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-akscluster"
+    readinessChecks:
+    - type: None
+  - name: providerConfig-kubernetes
+    base:
+      apiVersion: kubernetes.crossplane.io/v1alpha1
+      kind: ProviderConfig
+      spec:
+        credentials:
+          source: Secret
+          secretRef:
+            key: kubeconfig
+    patches:
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: metadata.name
+    - type: PatchSet
+      patchSetName: deletionPolicy
+    - fromFieldPath: spec.writeConnectionSecretToRef.namespace
+      toFieldPath: spec.credentials.secretRef.namespace
+    - fromFieldPath: metadata.uid
+      toFieldPath: spec.credentials.secretRef.name
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-akscluster"
+    readinessChecks:
+    - type: None

--- a/apis/azure/aks/definition.yaml
+++ b/apis/azure/aks/definition.yaml
@@ -42,7 +42,7 @@ spec:
                     type: string
                     default: default
                   version:
-                    description: Kubernetes version 
+                    description: Kubernetes version
                     type: string
                     enum:
                     - "1.27.3"
@@ -56,16 +56,13 @@ spec:
                       count:
                         type: integer
                         description: Desired node count
-                      size:
+                      instanceType:
                         type: string
-                        description: Size of node.
-                        enum:
-                        - small
-                        - medium
-                        - large
+                        description: instance types associated with the Node Group.
+                        default: Standard_B2s
                     required:
                     - count
-                    - size
+                    - instanceType
                 required:
                 - id
                 - region

--- a/apis/azure/composition.yaml
+++ b/apis/azure/composition.yaml
@@ -48,8 +48,8 @@ spec:
           toFieldPath: spec.parameters.version
         - fromFieldPath: spec.parameters.nodes.count
           toFieldPath: spec.parameters.nodes.count
-        - fromFieldPath: spec.parameters.nodes.size
-          toFieldPath: spec.parameters.nodes.size
+        - fromFieldPath: spec.parameters.nodes.instanceType
+          toFieldPath: spec.parameters.nodes.instanceType
     - base:
         apiVersion: azure.caas.upbound.io/v1alpha1
         kind: XServices
@@ -62,6 +62,8 @@ spec:
           toFieldPath: spec.operators.flux.version
         - fromFieldPath: spec.parameters.gitops.url
           toFieldPath: spec.gitops.url
+        - fromFieldPath: spec.parameters.gitops.path
+          toFieldPath: spec.gitops.path
         - fromFieldPath: spec.parameters.gitops.kubeConfigSecretRef.name
           toFieldPath: spec.gitops.kubeConfigSecretRef.name
         - fromFieldPath: spec.parameters.gitops.kubeConfigSecretRef.namespace

--- a/apis/azure/composition.yaml
+++ b/apis/azure/composition.yaml
@@ -55,7 +55,7 @@ spec:
         kind: XServices
       patches:
         - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
         - fromFieldPath: spec.parameters.id
           toFieldPath: spec.providerConfigRef.name
         - fromFieldPath: spec.parameters.services.operators.flux.version

--- a/apis/azure/definition.yaml
+++ b/apis/azure/definition.yaml
@@ -72,16 +72,13 @@ spec:
                       count:
                         type: integer
                         description: Desired node count, from 1 to 100.
-                      size:
+                      instanceType:
                         type: string
-                        description: Size of node.
-                        enum:
-                        - small
-                        - medium
-                        - large
+                        description: instance types associated with the Node Group.
+                        default: Standard_B2s
                     required:
                     - count
-                    - size
+                    - instanceType
                   gitops:
                     type: object
                     description: GitOps configure external gitops system for mcp controlplane
@@ -89,6 +86,9 @@ spec:
                       url:
                         type: string
                         description: Url for GitOps Sync.
+                      path:
+                        type: string
+                        description: path in Repo for GitOps Sync.
                       kubeConfigSecretRef:
                         type: object
                         description: location for kubeconfig mcp controlplane
@@ -103,7 +103,6 @@ spec:
                         - name
                         - namespace
                     required:
-                    - kubeConfigSecretRef
                     - url
                   services:
                     type: object

--- a/apis/azure/network/basic/composition.yaml
+++ b/apis/azure/network/basic/composition.yaml
@@ -11,97 +11,91 @@ spec:
     apiVersion: azure.caas.upbound.io/v1alpha1
     kind: XNetwork
   patchSets:
-    - name: providerConfigRef
-      patches:
-      - type: FromCompositeFieldPath
-        fromFieldPath: spec.parameters.providerConfigName
-        toFieldPath: spec.providerConfigRef.name
-    - name: deletionPolicy
-      patches:
-      - type: FromCompositeFieldPath
-        fromFieldPath: spec.parameters.deletionPolicy
-        toFieldPath: spec.deletionPolicy
-    - name: network-id
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: spec.parameters.id
-          toFieldPath: metadata.labels[azure.caas.upbound.io/network-id]
-    - name: region
-      patches:
-      - type: FromCompositeFieldPath
-        fromFieldPath: spec.parameters.region
-        toFieldPath: spec.forProvider.location
+  - name: providerConfigRef
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.providerConfigName
+      toFieldPath: spec.providerConfigRef.name
+  - name: deletionPolicy
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
+  - name: network-id
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.id
+      toFieldPath: metadata.labels[azure.caas.upbound.io/network-id]
+  - name: region
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.region
+      toFieldPath: spec.forProvider.location
   resources:
-    - name: resource-group
-      base:
-        apiVersion: azure.upbound.io/v1beta1
-        kind: ResourceGroup
-      patches:
-        - type: PatchSet
-          patchSetName: providerConfigRef
-        - type: PatchSet
-          patchSetName: deletionPolicy
-        - type: PatchSet
-          patchSetName: network-id
-        - type: PatchSet
-          patchSetName: region
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: metadata.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-rg"
-    - name: virtual-network
-      base:
-        apiVersion: network.azure.upbound.io/v1beta1
-        kind: VirtualNetwork
-        spec:
-          forProvider:
-            resourceGroupNameSelector:
-              matchControllerRef: true
-            addressSpace:
-              - 192.168.0.0/16
-      patches:
-        - type: PatchSet
-          patchSetName: providerConfigRef
-        - type: PatchSet
-          patchSetName: deletionPolicy
-        - type: PatchSet
-          patchSetName: network-id
-        - type: PatchSet
-          patchSetName: region
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: metadata.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-vnet"
-    - name: subnet
-      base:
-        apiVersion: network.azure.upbound.io/v1beta1
-        kind: Subnet
-        spec:
-          forProvider:
-            resourceGroupNameSelector:
-              matchControllerRef: true
-            virtualNetworkNameSelector:
-              matchControllerRef: true
-            addressPrefixes:
-              - 192.168.1.0/24
-            serviceEndpoints:
-              - Microsoft.Sql
-      patches:
-        - type: PatchSet
-          patchSetName: providerConfigRef
-        - type: PatchSet
-          patchSetName: deletionPolicy
-        - type: PatchSet
-          patchSetName: network-id
-        - type: PatchSet
-          patchSetName: region
-        - fromFieldPath: spec.parameters.id
-          toFieldPath: metadata.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-sn"
+  - name: resource-group
+    base:
+      apiVersion: azure.upbound.io/v1beta1
+      kind: ResourceGroup
+    patches:
+    - type: PatchSet
+      patchSetName: providerConfigRef
+    - type: PatchSet
+      patchSetName: deletionPolicy
+    - type: PatchSet
+      patchSetName: network-id
+    - type: PatchSet
+      patchSetName: region
+  - name: virtual-network
+    base:
+      apiVersion: network.azure.upbound.io/v1beta1
+      kind: VirtualNetwork
+      spec:
+        forProvider:
+          resourceGroupNameSelector:
+            matchControllerRef: true
+          addressSpace:
+          - 192.168.0.0/16
+    patches:
+    - type: PatchSet
+      patchSetName: providerConfigRef
+    - type: PatchSet
+      patchSetName: deletionPolicy
+    - type: PatchSet
+      patchSetName: network-id
+    - type: PatchSet
+      patchSetName: region
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: metadata.name
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-vnet"
+  - name: subnet
+    base:
+      apiVersion: network.azure.upbound.io/v1beta1
+      kind: Subnet
+      spec:
+        forProvider:
+          resourceGroupNameSelector:
+            matchControllerRef: true
+          virtualNetworkNameSelector:
+            matchControllerRef: true
+          addressPrefixes:
+          - 192.168.1.0/24
+          serviceEndpoints:
+          - Microsoft.Sql
+    patches:
+    - type: PatchSet
+      patchSetName: providerConfigRef
+    - type: PatchSet
+      patchSetName: deletionPolicy
+    - type: PatchSet
+      patchSetName: network-id
+    - type: PatchSet
+      patchSetName: region
+    - fromFieldPath: spec.parameters.id
+      toFieldPath: metadata.name
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-sn"

--- a/apis/azure/network/basic/composition.yaml
+++ b/apis/azure/network/basic/composition.yaml
@@ -82,8 +82,6 @@ spec:
             matchControllerRef: true
           addressPrefixes:
           - 192.168.1.0/24
-          serviceEndpoints:
-          - Microsoft.Sql
     patches:
     - type: PatchSet
       patchSetName: providerConfigRef
@@ -91,8 +89,6 @@ spec:
       patchSetName: deletionPolicy
     - type: PatchSet
       patchSetName: network-id
-    - type: PatchSet
-      patchSetName: region
     - fromFieldPath: spec.parameters.id
       toFieldPath: metadata.name
       transforms:

--- a/apis/azure/network/definition.yaml
+++ b/apis/azure/network/definition.yaml
@@ -8,41 +8,41 @@ spec:
     kind: XNetwork
     plural: xnetworks
   versions:
-    - name: v1alpha1
-      served: true
-      referenceable: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                parameters:
-                  description: Network Parameters
-                  properties:
-                    id:
-                      type: string
-                      description: ID of this Network that other objects will use to refer to it.
-                    region:
-                      type: string
-                      description: Region is the region you'd like your resource to be created in.
-                    deletionPolicy:
-                      description: When the Composition is deleted, delete the Azure resources. Defaults to Delete
-                      enum:
-                      - Delete
-                      - Orphan
-                      type: string
-                      default: Delete
-                    providerConfigName:
-                      description: Crossplane ProviderConfig to use for provisioning this resources
-                      type: string
-                      default: default
-                  required:
-                  - deletionPolicy
-                  - providerConfigName
-                  - id
-                  - region
-                  type: object
-              required:
-                - parameters
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              parameters:
+                description: Network Parameters
+                properties:
+                  id:
+                    type: string
+                    description: ID of this Network that other objects will use to refer to it.
+                  region:
+                    type: string
+                    description: Region is the region you'd like your resource to be created in.
+                  deletionPolicy:
+                    description: When the Composition is deleted, delete the Azure resources. Defaults to Delete
+                    enum:
+                    - Delete
+                    - Orphan
+                    type: string
+                    default: Delete
+                  providerConfigName:
+                    description: Crossplane ProviderConfig to use for provisioning this resources
+                    type: string
+                    default: default
+                required:
+                - deletionPolicy
+                - providerConfigName
+                - id
+                - region
+                type: object
+            required:
+            - parameters

--- a/apis/azure/services/default/composition.yaml
+++ b/apis/azure/services/default/composition.yaml
@@ -22,7 +22,7 @@ spec:
       fromFieldPath: spec.providerConfigRef.name
       toFieldPath: spec.providerConfigRef.name
     - type: FromCompositeFieldPath
-      fromFieldPath: spec.parameters.deletionPolicy
+      fromFieldPath: spec.deletionPolicy
       toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux

--- a/apis/azure/services/default/composition.yaml
+++ b/apis/azure/services/default/composition.yaml
@@ -9,6 +9,21 @@ spec:
   compositeTypeRef:
     apiVersion: azure.caas.upbound.io/v1alpha1
     kind: XServices
+  patchSets:
+  - name: Common
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.labels
+      toFieldPath: metadata.labels
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.annotations
+      toFieldPath: metadata.annotations
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.providerConfigRef.name
+      toFieldPath: spec.providerConfigRef.name
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux
       base:
@@ -28,14 +43,8 @@ spec:
               imageReflectionController:
                 create: false
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.operators.flux.version
           toFieldPath: spec.forProvider.chart.version
         - type: CombineFromComposite
@@ -47,3 +56,44 @@ spec:
             string:
               fmt: https://github.com/fluxcd-community/helm-charts/releases/download/flux2-%s/flux2-%s.tgz
           toFieldPath: spec.forProvider.chart.url
+    - name: syncFlux
+      base:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        spec:
+          rollbackLimit: 3
+          forProvider:
+            namespace: flux-system
+            chart:
+              name: flux2-sync
+              repository: https://fluxcd-community.github.io/helm-charts
+              # ToDo(haarchri): patch from outside
+              version: "1.6.2"
+            values:
+              gitRepository:
+                spec:
+                  timeout: 20s
+                  interval: 10m0s
+                  gitImplementation: go-git
+                  ref:
+                    branch: main
+              kustomization:
+                spec:
+                  interval: 10m
+                  sourceRef:
+                    kind: GitRepository
+      patches:
+        - type: PatchSet
+          patchSetName: Common
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: spec.gitops.url
+          toFieldPath: spec.forProvider.values.gitRepository.spec.url
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: spec.forProvider.values.kustomization.spec.path
+          transforms:
+            - type: string
+              string:
+                fmt: "./infrastructure/%s"
+        - fromFieldPath: spec.gitops.path
+          toFieldPath: spec.forProvider.values.kustomization.spec.path

--- a/apis/azure/services/definition.yaml
+++ b/apis/azure/services/definition.yaml
@@ -32,6 +32,9 @@ spec:
                   url:
                     type: string
                     description: Url for GitOps Sync.
+                  path:
+                    type: string
+                    description: path in Repo for GitOps Sync.
                   kubeConfigSecretRef:
                     type: object
                     description: location for kubeconfig mcp controlplane
@@ -46,7 +49,6 @@ spec:
                     - name
                     - namespace
                 required:
-                - kubeConfigSecretRef
                 - url
               operators:
                 type: object

--- a/apis/azure/services/gitops-master/composition.yaml
+++ b/apis/azure/services/gitops-master/composition.yaml
@@ -22,7 +22,7 @@ spec:
       fromFieldPath: spec.providerConfigRef.name
       toFieldPath: spec.providerConfigRef.name
     - type: FromCompositeFieldPath
-      fromFieldPath: spec.parameters.deletionPolicy
+      fromFieldPath: spec.deletionPolicy
       toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux

--- a/apis/azure/services/gitops-master/composition.yaml
+++ b/apis/azure/services/gitops-master/composition.yaml
@@ -9,6 +9,21 @@ spec:
   compositeTypeRef:
     apiVersion: azure.caas.upbound.io/v1alpha1
     kind: XServices
+  patchSets:
+  - name: Common
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.labels
+      toFieldPath: metadata.labels
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.annotations
+      toFieldPath: metadata.annotations
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.providerConfigRef.name
+      toFieldPath: spec.providerConfigRef.name
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux
       base:
@@ -28,14 +43,8 @@ spec:
               imageReflectionController:
                 create: false
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.operators.flux.version
           toFieldPath: spec.forProvider.chart.version
         - type: CombineFromComposite
@@ -65,14 +74,8 @@ spec:
               metadata:
                 namespace: flux-system
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.gitops.kubeConfigSecretRef.name
           toFieldPath: spec.references[0].patchesFrom.name
         - fromFieldPath: spec.gitops.kubeConfigSecretRef.namespace
@@ -110,14 +113,8 @@ spec:
                     secretRef:
                       key: kubeconfig
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.providerConfigRef.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
         - fromFieldPath: spec.gitops.url

--- a/apis/gcp/composition.yaml
+++ b/apis/gcp/composition.yaml
@@ -50,8 +50,8 @@ spec:
           toFieldPath: spec.parameters.version
         - fromFieldPath: spec.parameters.nodes.count
           toFieldPath: spec.parameters.nodes.count
-        - fromFieldPath: spec.parameters.nodes.size
-          toFieldPath: spec.parameters.nodes.size
+        - fromFieldPath: spec.parameters.nodes.instanceType
+          toFieldPath: spec.parameters.nodes.instanceType
     - base:
         apiVersion: gcp.caas.upbound.io/v1alpha1
         kind: XServices
@@ -64,6 +64,8 @@ spec:
           toFieldPath: spec.operators.flux.version
         - fromFieldPath: spec.parameters.gitops.url
           toFieldPath: spec.gitops.url
+        - fromFieldPath: spec.parameters.gitops.path
+          toFieldPath: spec.gitops.path
         - fromFieldPath: spec.parameters.gitops.kubeConfigSecretRef.name
           toFieldPath: spec.gitops.kubeConfigSecretRef.name
         - fromFieldPath: spec.parameters.gitops.kubeConfigSecretRef.namespace

--- a/apis/gcp/composition.yaml
+++ b/apis/gcp/composition.yaml
@@ -57,7 +57,7 @@ spec:
         kind: XServices
       patches:
         - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.parameters.deletionPolicy
+          toFieldPath: spec.deletionPolicy
         - fromFieldPath: spec.parameters.id
           toFieldPath: spec.providerConfigRef.name
         - fromFieldPath: spec.parameters.services.operators.flux.version

--- a/apis/gcp/definition.yaml
+++ b/apis/gcp/definition.yaml
@@ -70,16 +70,13 @@ spec:
                       count:
                         type: integer
                         description: Desired node count, from 1 to 100.
-                      size:
+                      instanceType:
                         type: string
-                        description: Size of node.
-                        enum:
-                        - small
-                        - medium
-                        - large
+                        description: instance types associated with the Node Group.
+                        default: n1-standard-4
                     required:
                     - count
-                    - size
+                    - instanceType
                   gitops:
                     type: object
                     description: GitOps configure external gitops system for mcp controlplane
@@ -87,6 +84,9 @@ spec:
                       url:
                         type: string
                         description: Url for GitOps Sync.
+                      path:
+                        type: string
+                        description: path in Repo for GitOps Sync.
                       kubeConfigSecretRef:
                         type: object
                         description: location for kubeconfig mcp controlplane
@@ -101,7 +101,6 @@ spec:
                         - name
                         - namespace
                     required:
-                    - kubeConfigSecretRef
                     - url
                   services:
                     type: object

--- a/apis/gcp/gke/composition.yaml
+++ b/apis/gcp/gke/composition.yaml
@@ -205,8 +205,6 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.id
           toFieldPath: metadata.name
-        - type: PatchSet
-          patchSetName: deletionPolicy
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.credentials.secretRef.namespace
         - fromFieldPath: metadata.uid
@@ -242,8 +240,6 @@ spec:
       patches:
         - fromFieldPath: spec.parameters.id
           toFieldPath: metadata.name
-        - type: PatchSet
-          patchSetName: deletionPolicy
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.credentials.secretRef.namespace
         - fromFieldPath: metadata.uid

--- a/apis/gcp/gke/composition.yaml
+++ b/apis/gcp/gke/composition.yaml
@@ -176,14 +176,8 @@ spec:
           patchSetName: deletionPolicy
         - type: PatchSet
           patchSetName: region
-        - fromFieldPath: spec.parameters.nodes.size
+        - fromFieldPath: spec.parameters.nodes.instanceType
           toFieldPath: spec.forProvider.nodeConfig[0].machineType
-          transforms:
-            - type: map
-              map:
-                small: n1-standard-4
-                medium: n1-standard-16
-                large: n1-standard-32
         - fromFieldPath: spec.parameters.nodes.count
           toFieldPath: spec.forProvider.initialNodeCount
         - fromFieldPath: spec.parameters.nodes.count

--- a/apis/gcp/gke/definition.yaml
+++ b/apis/gcp/gke/definition.yaml
@@ -54,16 +54,13 @@ spec:
                       count:
                         type: integer
                         description: Desired node count, from 1 to 100.
-                      size:
+                      instanceType:
                         type: string
-                        description: Size of node.
-                        enum:
-                        - small
-                        - medium
-                        - large
+                        description: instance types associated with the Node Group.
+                        default: n1-standard-4
                     required:
                     - count
-                    - size
+                    - instanceType
                 required:
                 - id
                 - region

--- a/apis/gcp/services/default/composition.yaml
+++ b/apis/gcp/services/default/composition.yaml
@@ -9,6 +9,21 @@ spec:
   compositeTypeRef:
     apiVersion: gcp.caas.upbound.io/v1alpha1
     kind: XServices
+  patchSets:
+  - name: Common
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.labels
+      toFieldPath: metadata.labels
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.annotations
+      toFieldPath: metadata.annotations
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.providerConfigRef.name
+      toFieldPath: spec.providerConfigRef.name
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux
       base:
@@ -28,14 +43,8 @@ spec:
               imageReflectionController:
                 create: false
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.operators.flux.version
           toFieldPath: spec.forProvider.chart.version
         - type: CombineFromComposite
@@ -47,3 +56,44 @@ spec:
             string:
               fmt: https://github.com/fluxcd-community/helm-charts/releases/download/flux2-%s/flux2-%s.tgz
           toFieldPath: spec.forProvider.chart.url
+    - name: syncFlux
+      base:
+        apiVersion: helm.crossplane.io/v1beta1
+        kind: Release
+        spec:
+          rollbackLimit: 3
+          forProvider:
+            namespace: flux-system
+            chart:
+              name: flux2-sync
+              repository: https://fluxcd-community.github.io/helm-charts
+              # ToDo(haarchri): patch from outside
+              version: "1.6.2"
+            values:
+              gitRepository:
+                spec:
+                  timeout: 20s
+                  interval: 10m0s
+                  gitImplementation: go-git
+                  ref:
+                    branch: main
+              kustomization:
+                spec:
+                  interval: 10m
+                  sourceRef:
+                    kind: GitRepository
+      patches:
+        - type: PatchSet
+          patchSetName: Common
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - fromFieldPath: spec.gitops.url
+          toFieldPath: spec.forProvider.values.gitRepository.spec.url
+        - fromFieldPath: spec.providerConfigRef.name
+          toFieldPath: spec.forProvider.values.kustomization.spec.path
+          transforms:
+            - type: string
+              string:
+                fmt: "./infrastructure/%s"
+        - fromFieldPath: spec.gitops.path
+          toFieldPath: spec.forProvider.values.kustomization.spec.path

--- a/apis/gcp/services/default/composition.yaml
+++ b/apis/gcp/services/default/composition.yaml
@@ -22,7 +22,7 @@ spec:
       fromFieldPath: spec.providerConfigRef.name
       toFieldPath: spec.providerConfigRef.name
     - type: FromCompositeFieldPath
-      fromFieldPath: spec.parameters.deletionPolicy
+      fromFieldPath: spec.deletionPolicy
       toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux

--- a/apis/gcp/services/definition.yaml
+++ b/apis/gcp/services/definition.yaml
@@ -32,6 +32,9 @@ spec:
                   url:
                     type: string
                     description: Url for GitOps Sync.
+                  path:
+                    type: string
+                    description: path in Repo for GitOps Sync.
                   kubeConfigSecretRef:
                     type: object
                     description: location for kubeconfig mcp controlplane
@@ -46,7 +49,6 @@ spec:
                     - name
                     - namespace
                 required:
-                - kubeConfigSecretRef
                 - url
               operators:
                 type: object

--- a/apis/gcp/services/gitops-master/composition.yaml
+++ b/apis/gcp/services/gitops-master/composition.yaml
@@ -9,6 +9,21 @@ spec:
   compositeTypeRef:
     apiVersion: gcp.caas.upbound.io/v1alpha1
     kind: XServices
+  patchSets:
+  - name: Common
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.labels
+      toFieldPath: metadata.labels
+    - type: FromCompositeFieldPath
+      fromFieldPath: metadata.annotations
+      toFieldPath: metadata.annotations
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.providerConfigRef.name
+      toFieldPath: spec.providerConfigRef.name
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux
       base:
@@ -28,14 +43,8 @@ spec:
               imageReflectionController:
                 create: false
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.operators.flux.version
           toFieldPath: spec.forProvider.chart.version
         - type: CombineFromComposite
@@ -65,14 +74,8 @@ spec:
               metadata:
                 namespace: flux-system
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.gitops.kubeConfigSecretRef.name
           toFieldPath: spec.references[0].patchesFrom.name
         - fromFieldPath: spec.gitops.kubeConfigSecretRef.namespace
@@ -110,14 +113,8 @@ spec:
                     secretRef:
                       key: kubeconfig
       patches:
-        - fromFieldPath: metadata.labels
-          toFieldPath: metadata.labels
-        - fromFieldPath: metadata.annotations
-          toFieldPath: metadata.annotations
-        - fromFieldPath: spec.providerConfigRef.name
-          toFieldPath: spec.providerConfigRef.name
-        - fromFieldPath: spec.parameters.deletionPolicy
-          toFieldPath: spec.deletionPolicy
+        - type: PatchSet
+          patchSetName: Common
         - fromFieldPath: spec.providerConfigRef.name
           toFieldPath: metadata.annotations[crossplane.io/external-name]
         - fromFieldPath: spec.gitops.url

--- a/apis/gcp/services/gitops-master/composition.yaml
+++ b/apis/gcp/services/gitops-master/composition.yaml
@@ -22,7 +22,7 @@ spec:
       fromFieldPath: spec.providerConfigRef.name
       toFieldPath: spec.providerConfigRef.name
     - type: FromCompositeFieldPath
-      fromFieldPath: spec.parameters.deletionPolicy
+      fromFieldPath: spec.deletionPolicy
       toFieldPath: spec.deletionPolicy
   resources:
     - name: releaseFlux


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
**Refactor:**

- for gitops-master, refactor xservice compositions to utilize patchSet.
- In the xnetwork composition, remove the tag from VPC and set metadata.name for tags.Name to ensure the correct name is displayed in the AWS console.
- change node `size` to `instanceType`

**Additions:**

- Add an optional path for xservice to configure its location within the GitOps repository.
- Introduce xirsa composition.
- Enhance the xeks composition with the ability to generate a Kubernetes ConfigMap containing IRSA OIDC information, add aws-auth ConfigMap Object

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
NAME                                                        CHART        VERSION   SYNCED   READY   STATE      REVISION   DESCRIPTION        AGE
release.helm.crossplane.io/haarchri-spaces-01-lndwd-jsk7s   flux2-sync   1.6.2     True     True    deployed   1          Install complete   22h
release.helm.crossplane.io/haarchri-spaces-01-lndwd-mtc44   flux2        2.9.2     True     True    deployed   1          Install complete   22h

NAME                                                                                   KIND        PROVIDERCONFIG       SYNCED   READY   AGE
object.kubernetes.crossplane.io/aws-loadbalancer-controller-vx9kd                      ConfigMap   haarchri-spaces-01   True     True    82m
object.kubernetes.crossplane.io/haarchri-spaces-01-aws-loadbalancer-controller-tr7h2   ConfigMap   haarchri-spaces-01   True     True    75m
object.kubernetes.crossplane.io/haarchri-spaces-01-external-dns-rstft                  ConfigMap   haarchri-spaces-01   True     True    75m
object.kubernetes.crossplane.io/haarchri-spaces-01-flux-kustomize-controller-7p7bg     ConfigMap   haarchri-spaces-01   True     True    74m
object.kubernetes.crossplane.io/haarchri-spaces-01-irsa-settings                       ConfigMap   haarchri-spaces-01   True     True    93m

NAME                                                       READY   SYNCED   EXTERNAL-NAME              AGE
subnet.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-269t8   True    True     subnet-0933984407a0a2019   22h
subnet.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-6btft   True    True     subnet-0aa0e4616b452aaf0   22h
subnet.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-kbn8h   True    True     subnet-0446bc04c8d50abb5   22h
subnet.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-snxvj   True    True     subnet-0a81371b66cf11c88   22h

NAME                                                                READY   SYNCED   EXTERNAL-NAME           AGE
internetgateway.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-p8zlw   True    True     igw-035581722e200d004   22h

NAME                                                                          READY   SYNCED   EXTERNAL-NAME                AGE
mainroutetableassociation.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-bcc4t   True    True     rtbassoc-02c00c400018b16d8   22h

NAME                                                                      READY   SYNCED   EXTERNAL-NAME                AGE
routetableassociation.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-8tq2x   True    True     rtbassoc-09ba7bffe9758d510   22h
routetableassociation.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-jf6xh   True    True     rtbassoc-0b4767567aeaefa2f   22h
routetableassociation.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-ld577   True    True     rtbassoc-0180c601a3025d6c9   22h
routetableassociation.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-n4sc8   True    True     rtbassoc-017f540944ee04b3d   22h

NAME                                                      READY   SYNCED   EXTERNAL-NAME                       AGE
route.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-469zm   True    True     r-rtb-00b3db5beab20f9751080289494   22h

NAME                                                    READY   SYNCED   EXTERNAL-NAME           AGE
vpc.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-l9lh2   True    True     vpc-04e5098c5dc9fba25   22h

NAME                                                           READY   SYNCED   EXTERNAL-NAME           AGE
routetable.ec2.aws.upbound.io/haarchri-spaces-01-lndwd-25hgq   True    True     rtb-00b3db5beab20f975   22h

NAME                                                            READY   SYNCED   EXTERNAL-NAME                    AGE
clusterauth.eks.aws.upbound.io/haarchri-spaces-01-lndwd-jqzb7   True    True     haarchri-spaces-01-lndwd-jqzb7   22h

NAME                                                      READY   SYNCED   EXTERNAL-NAME                                       AGE
addon.eks.aws.upbound.io/haarchri-spaces-01-lndwd-jb2nh   True    True     haarchri-spaces-01-lndwd-r5d94:aws-ebs-csi-driver   22h

NAME                                                          READY   SYNCED   EXTERNAL-NAME                    AGE
nodegroup.eks.aws.upbound.io/haarchri-spaces-01-lndwd-r2gc6   True    True     haarchri-spaces-01-lndwd-r2gc6   22h

NAME                                                        READY   SYNCED   EXTERNAL-NAME                    AGE
cluster.eks.aws.upbound.io/haarchri-spaces-01-lndwd-r5d94   True    True     haarchri-spaces-01-lndwd-r5d94   22h

NAME                                                                             READY   SYNCED   EXTERNAL-NAME                                          AGE
policy.iam.aws.upbound.io/aws-loadbalancer-controller-ghvcw                      True    True     aws-loadbalancer-controller-ghvcw                      21h
policy.iam.aws.upbound.io/haarchri-spaces-01-aws-loadbalancer-controller-l8h7d   True    True     haarchri-spaces-01-aws-loadbalancer-controller-l8h7d   21h
policy.iam.aws.upbound.io/haarchri-spaces-01-external-dns-ws59m                  True    True     haarchri-spaces-01-external-dns-ws59m                  21h
policy.iam.aws.upbound.io/haarchri-spaces-01-flux-kustomize-controller-rxrbq     True    True     haarchri-spaces-01-flux-kustomize-controller-rxrbq     20h

NAME                                                                      READY   SYNCED   EXTERNAL-NAME                                                                                                     AGE
openidconnectprovider.iam.aws.upbound.io/haarchri-spaces-01-lndwd-zptgl   True    True     arn:aws:iam::609897127049:oidc-provider/oidc.eks.eu-central-1.amazonaws.com/id/02053DCA0262B21293420E0A3B39E81B   21h

NAME                                                                                           READY   SYNCED   EXTERNAL-NAME                                                               AGE
rolepolicyattachment.iam.aws.upbound.io/aws-loadbalancer-controller-9m4ks                      True    True     aws-loadbalancer-controller-20230831125548395800000001                      21h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-aws-loadbalancer-controller-dsdv5   True    True     haarchri-spaces-01-aws-loadbalancer-controller-20230831133727464400000002   21h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-external-dns-rvrlc                  True    True     haarchri-spaces-01-external-dns-20230831133717296800000001                  21h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-flux-kustomize-controller-qnwn2     True    True     haarchri-spaces-01-flux-kustomize-controller-20230831135957793400000001     20h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-lndwd-6xt5b                         True    True     haarchri-spaces-01-lndwd-z59m8-20230831124019105800000003                   22h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-lndwd-c8kgc                         True    True     haarchri-spaces-01-lndwd-z59m8-20230831124018687300000002                   22h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-lndwd-ggjtb                         True    True     haarchri-spaces-01-lndwd-z59m8-20230831124056319900000004                   22h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-lndwd-gh8z8                         True    True     haarchri-spaces-01-lndwd-z59m8-20230831124056762100000005                   22h
rolepolicyattachment.iam.aws.upbound.io/haarchri-spaces-01-lndwd-mgprg                         True    True     haarchri-spaces-01-lndwd-mt5wd-20230831124018604000000001                   22h

NAME                                                                           READY   SYNCED   EXTERNAL-NAME                                    AGE
role.iam.aws.upbound.io/aws-loadbalancer-controller-f6qbb                      True    True     aws-loadbalancer-controller                      21h
role.iam.aws.upbound.io/haarchri-spaces-01-aws-loadbalancer-controller-74qll   True    True     haarchri-spaces-01-aws-loadbalancer-controller   21h
role.iam.aws.upbound.io/haarchri-spaces-01-external-dns-h89pm                  True    True     haarchri-spaces-01-external-dns                  21h
role.iam.aws.upbound.io/haarchri-spaces-01-flux-kustomize-controller-ksgzv     True    True     haarchri-spaces-01-flux-kustomize-controller     20h
role.iam.aws.upbound.io/haarchri-spaces-01-lndwd-mt5wd                         True    True     haarchri-spaces-01-lndwd-mt5wd                   22h
role.iam.aws.upbound.io/haarchri-spaces-01-lndwd-z59m8                         True    True     haarchri-spaces-01-lndwd-z59m8                   22h

```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
