### PR TITLE
feat(eks): add diskSize

### DIFF
--- a/apis/aws/eks/composition.yaml
+++ b/apis/aws/eks/composition.yaml
@@ -256,6 +256,7 @@ spec:
           forProvider:
             clusterNameSelector:
               matchControllerRef: true
+            diskSize: 100
             nodeRoleArnSelector:
               matchControllerRef: true
               matchLabels:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
When using CAAS and adding workloads, the initial configuration sets the default storage to 20GB. However, after a few deployments, we observe Disk Pressure issues. To address this, we are increasing the default xvda storage to 100GB instead of 20GB.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
