### PR TITLE
Update provider-kubernetes to v0.11.0, and migrate `Object` to v1alpha2

### DIFF
--- a/apis/aws/eks/composition.yaml
+++ b/apis/aws/eks/composition.yaml
@@ -372,7 +372,7 @@ spec:
         - type: None
     - name: irsa-settings
       base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
+        apiVersion: kubernetes.crossplane.io/v1alpha2
         kind: Object
         spec:
           deletionPolicy: Orphan
@@ -404,7 +404,7 @@ spec:
 
     - name: aws-auth
       base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
+        apiVersion: kubernetes.crossplane.io/v1alpha2
         kind: Object
         spec:
           deletionPolicy: Orphan

--- a/apis/aws/irsa/composition.yaml
+++ b/apis/aws/irsa/composition.yaml
@@ -131,7 +131,7 @@ spec:
 
     - name: irsa-settings
       base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
+        apiVersion: kubernetes.crossplane.io/v1alpha2
         kind: Object
         spec:
           managementPolicy: Observe

--- a/apis/aws/services/gitops-master/composition.yaml
+++ b/apis/aws/services/gitops-master/composition.yaml
@@ -58,7 +58,7 @@ spec:
           toFieldPath: spec.forProvider.chart.url
     - name: mcp-kubeconfig-transfer-secret
       base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
+        apiVersion: kubernetes.crossplane.io/v1alpha2
         kind: Object
         spec:
           references:

--- a/apis/azure/services/gitops-master/composition.yaml
+++ b/apis/azure/services/gitops-master/composition.yaml
@@ -58,7 +58,7 @@ spec:
           toFieldPath: spec.forProvider.chart.url
     - name: mcp-kubeconfig-transfer-secret
       base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
+        apiVersion: kubernetes.crossplane.io/v1alpha2
         kind: Object
         spec:
           references:

--- a/apis/gcp/services/gitops-master/composition.yaml
+++ b/apis/gcp/services/gitops-master/composition.yaml
@@ -58,7 +58,7 @@ spec:
           toFieldPath: spec.forProvider.chart.url
     - name: mcp-kubeconfig-transfer-secret
       base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
+        apiVersion: kubernetes.crossplane.io/v1alpha2
         kind: Object
         spec:
           references:

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -20,7 +20,7 @@ spec:
     - provider: xpkg.upbound.io/crossplane-contrib/provider-helm
       version: ">=v0.15.0"
     - provider: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
-      version: ">=v0.9.0"
+      version: ">=v0.11.0"
     - provider: xpkg.upbound.io/upbound/provider-aws-ec2
       version: ">=v0.38.0"
     - provider: xpkg.upbound.io/upbound/provider-aws-eks


### PR DESCRIPTION
### Description of your changes
With v0.11.0, provider-kubernetes introduced fine-grained management policies, and bumped the version on the `Object`  managed resource. This PR updates `Object` definitions in compositions, and sets a new minimum version for provider-kubernetes in the package configuration.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] ~~Run `make reviewable` to ensure this PR is ready for review.~~
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~~

